### PR TITLE
fix: nil guard for _custom_player_panel to prevent crash with Vanilla…

### DIFF
--- a/lua/hud/HudTeammate.lua
+++ b/lua/hud/HudTeammate.lua
@@ -795,6 +795,7 @@ if VoidUI.options.teammate_panels then
 		end
 	end
 	function HUDTeammate:set_detection()
+		if not self._custom_player_panel then return end
 		local health_panel = self._custom_player_panel:child("health_panel")
 		local detect_value = health_panel:child("detect_value")
 		local downs_value = health_panel:child("downs_value")

--- a/lua/hud/HudTeammate.lua
+++ b/lua/hud/HudTeammate.lua
@@ -759,6 +759,14 @@ if VoidUI.options.teammate_panels then
 		interact_time:set_bottom(self._custom_player_panel:bottom() - 3)
 		self:create_custom_waiting_panel(teammates_panel)
 		self:set_info_visible()
+		-- VanillaHUD Plus' HUDTeammate:_truncate_name() shrinks the name font by 0.1
+		-- in a loop. On our custom panel that loop is hot at spawn (set_name), and
+		-- under LuaJIT the float compare diverges from the interpreter so it never
+		-- exits and the game freezes. Force that one function to run interpreted.
+		if HUDTeammate._truncate_name and not HUDTeammate._void_truncate_jit_off and jit and jit.off then
+			HUDTeammate._void_truncate_jit_off = true
+			pcall(jit.off, HUDTeammate._truncate_name, true)
+		end
 	end
 
 	function HUDTeammate:whisper_mode_changed()


### PR DESCRIPTION
Note: The crash occurs in `set_detection()` (line 798), not `init()`.
`_custom_player_panel` is constructed inside `init()` at line 53;
VanillaHUD Plus triggers `set_detection()` during HUD rebuild before
`init()` completes, leaving the field nil.